### PR TITLE
Allows debugging from inside the Visual Studio IDE.

### DIFF
--- a/.vs/launch.vs.json
+++ b/.vs/launch.vs.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.2.1",
+  "defaults": {},
+  "configurations": [
+    {
+      "type": "default",
+      "project": "OBJ\\WINS\\3dmovie.exe",
+      "projectTarget": "",
+      "name": "3dmovie.exe"
+    }
+  ]
+}


### PR DESCRIPTION
Adds a [launch.vs.json](https://github.com/frank-weindel/3DMMForever/pull/1/files#diff-bb8dfbfba780d881e8c798fa412fcf214b3e01833bb0b35bfe044d834352842e) file for Visual Studio.

When the directory is open inside VS, should now have a debug option under Startup items.